### PR TITLE
Update for 0.20.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Using the zeebe-node module and exposing it as a NestJS transport and module.
 
             // Task worker business logic goes here
 
-            complete(updatedVariables);
+            complete.success(updatedVariables);
         }
 
         // Subscribe to events of type 'inventory-service and create a worker with the options as passed below (zeebe-node ZBWorkerOptions)
@@ -65,7 +65,7 @@ Using the zeebe-node module and exposing it as a NestJS transport and module.
 
             // Task worker business logic goes here
 
-            complete(updatedVariables);
+            complete.success(updatedVariables);
         }
     }
 

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "reflect-metadata": "^0.1.13",
     "rxjs": "^6.5.2",
     "typescript": "^3.6.3",
-    "zeebe-node": "^0.20.3"
+    "zeebe-node": "^0.20.6"
   },
   "devDependencies": {
     "ts-node": "^8.3.0",

--- a/src/zeebe.interfaces.ts
+++ b/src/zeebe.interfaces.ts
@@ -18,7 +18,7 @@ export interface ZeebeWorkerProperties {
  * @interface ZeebeClientOptions
  */
 export interface ZeebeClientOptions {
-    gatewayAddress: string;
+    gatewayAddress?: string;
     options?: ZBWorkerOptions & ZBClientOptions;
 }
 


### PR DESCRIPTION
Once we publish 0.20.6 to fix https://github.com/creditsenseau/zeebe-client-node-js/issues/74, this will pull it in, and also make the gateway address optional.

The library can now get its configuration from the environment if no gateway address is passed in (added in 0.20.5). It will default to localhost if no gateway address is supplied and no gateway address is passed to the constructor.

This allows you to write more portable code, without having to demarshall environment variables into the constructor.