### PR TITLE
Use zeebe-node 0.21.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@payk/nestjs-zeebe",
-  "version": "1.1.3",
+  "version": "1.2.0",
   "description": "Zeebe microservice module and client for nestjs",
   "main": "dist/index.js",
   "repository": {
@@ -29,7 +29,7 @@
     "reflect-metadata": "^0.1.13",
     "rxjs": "^6.5.3",
     "typescript": "^3.6.3",
-    "zeebe-node": "^0.20.6"
+    "zeebe-node": "^0.21.0"
   },
   "devDependencies": {
     "@nestjs/testing": "^6.7.1",


### PR DESCRIPTION
0.21 of the Zeebe broker is out. Use 0.21.0 of the zeebe-node library to get the goodness.