### PR TITLE
Update zeebe.module.spec.ts

### DIFF
--- a/src/zeebe.module.spec.ts
+++ b/src/zeebe.module.spec.ts
@@ -9,7 +9,7 @@ describe('Winston module', function() {
   it('boots successfully', async function() {
     const rootModule = await Test.createTestingModule({
       imports: [
-        ZeebeModule.forRoot({ gatewayAddress: 'localhost:26500' }),
+        ZeebeModule.forRoot({}),
       ],
     }).compile();
 
@@ -19,7 +19,7 @@ describe('Winston module', function() {
   it('boots successfully asynchronously', async function() {
     @Injectable()
     class ConfigService {
-      public zeebeOptions = { gatewayAddress: 'localhost:26500' };
+      public zeebeOptions = { };
     }
 
     @Module({


### PR DESCRIPTION
By default, with no gateway supplied, the client will connect to localhost:26500. If you remove the explicit address you can set it via env vars, which is useful for automated testing.